### PR TITLE
Cervino changes 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "open62541"]
 	path = open62541
 	url = https://github.com/rjapeer/open62541.git
-	branch = fixes/1.3
+	branch = Cervino

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -6,29 +6,20 @@
       "configurationType": "Debug",
       "buildRoot": "${projectDir}\\build",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-T v140,host=x86 -DPYTHON_EXECUTABLE=\"%APPDATA%\\..\\Local\\Programs\\Python\\Python39\\python.exe\" -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_HISTORIZING=ON -DUA_DYNAMIC_LINKING=ON -DUA_DYNAMIC_LINKING_EXPORT=OFF -DUA_ENABLE_STATUSCODE_DESCRIPTIONS=ON -DUA_ARCHITECTURE:STRING=win32 -DUA_NAMESPACE_ZERO:STRING=FULL -DUA_FORCE_CPP=ON -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE --trace ",
+      "cmakeCommandArgs": "-T v140,host=x86",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "msvc_x86" ],
+      "_comment_variables": "Please keep these variables in sync with the ones defined in BuildOxsas\build_open62541.py",
       "variables": [
         {
           "name": "UA_LOGLEVEL",
-          "value": "300",
+          "value": "400",
           "type": "STRING"
         },
         {
-          "name": "UA_ENABLE_ENCRYPTION_OPENSSL",
-          "value": "False",
-          "type": "BOOL"
-        },
-        {
-          "name": "UA_ENABLE_ENCRYPTION",
-          "value": "OFF",
+          "name": "CMAKE_BUILD_TYPE",
+          "value": "Debug",
           "type": "STRING"
-        },
-        {
-          "name": "UA_ENABLE_DISCOVERY_MULTICAST",
-          "value": "False",
-          "type": "BOOL"
         },
         {
           "name": "UA_DEBUG",
@@ -37,11 +28,51 @@
         },
         {
           "name": "UA_MULTITHREADING",
-          "value": "0",
+          "value": "100",
           "type": "STRING"
         },
         {
+          "name": "UA_ENABLE_DISCOVERY",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_HISTORIZING",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_DYNAMIC_LINKING",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
           "name": "BUILD_SHARED_LIBS",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_FORCE_CPP",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ARCHITECTURE",
+          "value": "win32",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_NAMESPACE_ZERO",
+          "value": "FULL",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_ENABLE_JSON_ENCODING",
           "value": "True",
           "type": "BOOL"
         }
@@ -55,44 +86,75 @@
       "configurationType": "Release",
       "buildRoot": "${projectDir}\\build",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-T v140,host=x86 -DPYTHON_EXECUTABLE=\"%APPDATA%\\..\\Local\\Programs\\Python\\Python39\\python.exe\" -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_HISTORIZING=ON -DUA_DYNAMIC_LINKING=ON -DUA_DYNAMIC_LINKING_EXPORT=OFF -DUA_ENABLE_STATUSCODE_DESCRIPTIONS=ON -DUA_ARCHITECTURE:STRING=win32 -DUA_NAMESPACE_ZERO:STRING=FULL-DUA_FORCE_CPP=ON -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE --trace ",
-      "buildCommandArgs": "",
+      "cmakeCommandArgs": "-T v140,host=x86",
+      "buildCommandArgs": " /p:CharacterSet=Unicode",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "msvc_x86" ],
+      "_comment_variables": "Please keep these variables in sync with the ones defined in BuildOxsas\build_open62541.py",
       "variables": [
         {
-          "name": "UA_ENABLE_ENCRYPTION",
-          "value": "OFF",
+          "name": "UA_LOGLEVEL",
+          "value": "400",
           "type": "STRING"
         },
         {
-          "name": "UA_ENABLE_ENCRYPTION_TPM2",
-          "value": "OFF",
+          "name": "CMAKE_BUILD_TYPE",
+          "value": "Release",
           "type": "STRING"
         },
         {
-          "name": "UA_FORCE_32BIT",
+          "name": "UA_DEBUG",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_MULTITHREADING",
+          "value": "100",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_ENABLE_DISCOVERY",
           "value": "True",
           "type": "BOOL"
         },
         {
-          "name": "UA_ENABLE_PUBSUB_ENCRYPTION",
-          "value": "False",
+          "name": "UA_ENABLE_HISTORIZING",
+          "value": "True",
           "type": "BOOL"
         },
         {
-          "name": "UA_ENABLE_ENCRYPTION_OPENSSL",
-          "value": "False",
+          "name": "UA_DYNAMIC_LINKING",
+          "value": "True",
           "type": "BOOL"
         },
         {
-          "name": "UA_ENABLE_ENCRYPTION_MBEDTLS",
-          "value": "False",
+          "name": "BUILD_SHARED_LIBS",
+          "value": "True",
           "type": "BOOL"
         },
         {
-          "name": "UA_ENABLE_DISCOVERY_MULTICAST",
-          "value": "False",
+          "name": "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_FORCE_CPP",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ARCHITECTURE",
+          "value": "win32",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_NAMESPACE_ZERO",
+          "value": "FULL",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_ENABLE_JSON_ENCODING",
+          "value": "True",
           "type": "BOOL"
         }
       ]

--- a/include/open62541cpp/historydatabase.h
+++ b/include/open62541cpp/historydatabase.h
@@ -1248,22 +1248,42 @@ class MemoryHistorian : public Historian
 {
 public:
     MemoryHistorian(size_t numberNodes = 100, size_t maxValuesPerNode = 100);
-    ~MemoryHistorian() = default;
+    ~MemoryHistorian() override = default;
+};
+
+/**
+ * The SQLiteHistorianCyclicBuffer class
+ * This is the provided sqlite based persistent historian that provides a
+ * cyclic buffer. Adding new entries will remove the oldest ones once the
+ * maximum number of values per node is exceeded.
+ * Pruning old values is only done every pruneInterval times a new value is added.
+ * This can be used for improving performance, with a slight cost in storage space.
+ */
+class SQLiteHistorianCyclicBuffered : public Historian
+{
+public:
+    SQLiteHistorianCyclicBuffered(const char* dbFileName,
+                                  size_t numberNodes,
+                                  size_t maxValuesPerNode,
+                                  size_t pruneInterval);
+    ~SQLiteHistorianCyclicBuffered() override = default;
 };
 
 /**
  * The SQLiteHistorian class
- * This is the provided sqlite historian that adds persistency
+ * This is the provided sqlite based persistent historian that provides a
+ * time window buffer. New entries are always added, old entries are removed 
+ * Pruning old values is only done every pruneInterval times a new value is added.
+ * This can be used for improving performance, with a slight cost in storage space.
  */
-class SQLiteHistorian : public Historian
+class SQLiteHistorianTimeBuffered : public Historian
 {
 public:
-    SQLiteHistorian(const char* dbFileName, size_t numberNodes = 100, size_t maxValuesPerNode = 100);
-    SQLiteHistorian(const char* dbFileName,
-                    size_t numberNodes,
-                    size_t maxValuesPerNode,
-                    UA_DateTime maxBufferedTime);
-    ~SQLiteHistorian() = default;
+    SQLiteHistorianTimeBuffered(const char* dbFileName,
+                               size_t numberNodes,
+                               UA_DateTime maxBufferedTimeSec,
+                               size_t pruneInterval);
+    ~SQLiteHistorianTimeBuffered() override = default;
 };
 
 } // namespace Open62541

--- a/include/open62541cpp/historydatabase.h
+++ b/include/open62541cpp/historydatabase.h
@@ -17,6 +17,7 @@
 #include "open62541/plugin/historydata/history_data_gathering.h"
 #include "open62541/plugin/historydata/history_data_gathering_default.h"
 #include "open62541/plugin/historydata/history_data_backend_memory.h"
+#include "open62541/plugin/historydata/history_data_backend_sqlite.h"
 #include <open62541cpp/open62541server.h>
 
 namespace Open62541 {
@@ -1248,6 +1249,21 @@ class MemoryHistorian : public Historian
 public:
     MemoryHistorian(size_t numberNodes = 100, size_t maxValuesPerNode = 100);
     ~MemoryHistorian() = default;
+};
+
+/**
+ * The SQLiteHistorian class
+ * This is the provided sqlite historian that adds persistency
+ */
+class SQLiteHistorian : public Historian
+{
+public:
+    SQLiteHistorian(const char* dbFileName, size_t numberNodes = 100, size_t maxValuesPerNode = 100);
+    SQLiteHistorian(const char* dbFileName,
+                    size_t numberNodes,
+                    size_t maxValuesPerNode,
+                    UA_DateTime maxBufferedTime);
+    ~SQLiteHistorian() = default;
 };
 
 } // namespace Open62541

--- a/include/open62541cpp/historydatabase.h
+++ b/include/open62541cpp/historydatabase.h
@@ -1169,22 +1169,16 @@ public:
  */
 class Historian
 {
-protected:
-    // the parts
-    UA_HistoryDatabase      m_database;
-    UA_HistoryDataBackend   m_backend;
-    UA_HistoryDataGathering m_gathering;
-
 public:
     Historian();
 
     virtual ~Historian();
 
     // accessors
-    UA_HistoryDatabase&         database()  { return m_database; }
-    UA_HistoryDataGathering&    gathering() { return m_gathering; }
-    UA_HistoryDataBackend&      backend()   { return m_backend; }
-
+    UA_HistoryDatabase&      database();
+    UA_HistoryDataGathering& gathering();
+    UA_HistoryDataBackend&   backend();
+    
     /**
      * Registers a node for the gathering of historical data.
      * The values will be stored when a node is updated via write service.
@@ -1238,6 +1232,11 @@ public:
         size_t  responseSize = 100,
         size_t  pollInterval = 1000,
         void*   context      = nullptr);
+
+private:
+    UA_HistoryDatabase m_database;
+    UA_HistoryDataBackend m_backend;
+    UA_HistoryDataGathering m_gathering;
 };
 
 /**

--- a/include/open62541cpp/historydatabase.h
+++ b/include/open62541cpp/historydatabase.h
@@ -1269,7 +1269,7 @@ public:
 };
 
 /**
- * The SQLiteHistorian class
+ * The SQLiteHistorianTimeBuffered class
  * This is the provided sqlite based persistent historian that provides a
  * time window buffer. New entries are always added, old entries are removed 
  * Pruning old values is only done every pruneInterval times a new value is added.

--- a/include/open62541cpp/open62541objects.h
+++ b/include/open62541cpp/open62541objects.h
@@ -70,7 +70,9 @@
 //
 #if UA_MULTITHREADING >= 100
 // Sleep is function call in wxWidgets
+#ifdef UA_ARCHITECTURE_POSIX
 #include <pthread.h>
+#endif
 #undef Sleep
 #endif
 //

--- a/src/historydatabase.cpp
+++ b/src/historydatabase.cpp
@@ -558,8 +558,8 @@ Historian::Historian() {
 //*****************************************************************************
 
 Historian::~Historian() {
-    if (m_backend.context)
-        UA_HistoryDataBackend_Memory_clear(&m_backend);
+    m_backend.deleteMembers(&m_backend);
+    memset(&m_backend, 0, sizeof(m_backend));
 }
 
 //*****************************************************************************
@@ -644,4 +644,28 @@ MemoryHistorian::MemoryHistorian(
     backend()   = UA_HistoryDataBackend_Memory_Circular(numberNodes, maxValuesPerNode);
 }
 
-} // namespace Open62541
+//*****************************************************************************
+
+SQLiteHistorian::SQLiteHistorian(const char* dbFileName,
+                                     size_t numberNodes,
+                                     size_t maxValuesPerNode)
+{
+    size_t defaultPruneInterval = 10;
+    gathering() = UA_HistoryDataGathering_Default(numberNodes);
+    database()  = UA_HistoryDatabase_default(gathering());
+    UA_HistoryDataBackend memoryBackend = UA_HistoryDataBackend_Memory_Circular(numberNodes, maxValuesPerNode);
+    backend() = UA_HistoryDataBackend_SQLite_Circular(memoryBackend, dbFileName, defaultPruneInterval, maxValuesPerNode);
+}
+
+SQLiteHistorian::SQLiteHistorian(const char* dbFileName,
+                                 size_t numberNodes,
+                                 size_t maxValuesPerNode,
+                                 UA_DateTime maxBufferedTime)
+{
+    size_t defaultPruneInterval         = 10;
+    gathering()                         = UA_HistoryDataGathering_Default(numberNodes);
+    database()                          = UA_HistoryDatabase_default(gathering());
+    UA_HistoryDataBackend memoryBackend = UA_HistoryDataBackend_Memory_Circular(numberNodes, maxValuesPerNode);
+    backend() = UA_HistoryDataBackend_SQLite_Circular(memoryBackend, dbFileName, defaultPruneInterval, maxValuesPerNode);
+}
+}  // namespace Open62541

--- a/src/historydatabase.cpp
+++ b/src/historydatabase.cpp
@@ -670,7 +670,7 @@ SQLiteHistorianCyclicBuffered::SQLiteHistorianCyclicBuffered(const char* dbFileN
 {
     gathering() = UA_HistoryDataGathering_Default(numberNodes);
     database()  = UA_HistoryDatabase_default(gathering());
-    backend() = UA_HistoryDataBackend_SQLite_Circular(dbFileName, pruneInterval, maxValuesPerNode);
+    backend() = UA_HistoryDataBackend_SQLite_Circular(dbFileName, pruneInterval, maxValuesPerNode, FALSE);
 }
 
 SQLiteHistorianTimeBuffered::SQLiteHistorianTimeBuffered(const char* dbFileName,
@@ -680,7 +680,7 @@ SQLiteHistorianTimeBuffered::SQLiteHistorianTimeBuffered(const char* dbFileName,
 {
     gathering() = UA_HistoryDataGathering_Default(numberNodes);
     database()  = UA_HistoryDatabase_default(gathering());
-    backend()   = UA_HistoryDataBackend_SQLite_TimeBuffered(dbFileName, pruneInterval, maxBufferedTimeSec);
+    backend()   = UA_HistoryDataBackend_SQLite_TimeBuffered(dbFileName, pruneInterval, maxBufferedTimeSec, FALSE);
 }
 
 }  // namespace Open62541

--- a/src/historydatabase.cpp
+++ b/src/historydatabase.cpp
@@ -448,12 +448,12 @@ void HistoryDataBackend::initialise() {
 //*****************************************************************************
 
 void HistoryDatabase::initialise() {
-    m_database.context           = this;
-    m_database.clear             = _deleteMembers;
-    m_database.setValue          = _setValue;
-    m_database.readRaw           = _readRaw;
-    m_database.updateData        = _updateData;
-    m_database.deleteRawModified = _deleteRawModified;
+    database().context           = this;
+    database().clear             = _deleteMembers;
+    database().setValue          = _setValue;
+    database().readRaw           = _readRaw;
+    database().updateData        = _updateData;
+    database().deleteRawModified = _deleteRawModified;
 }
 
 //*****************************************************************************
@@ -564,6 +564,23 @@ Historian::~Historian() {
 
 //*****************************************************************************
 
+UA_HistoryDatabase& Historian::database()
+{
+    return m_database;
+}
+
+UA_HistoryDataGathering& Historian::gathering()
+{
+    return m_gathering;
+}
+
+UA_HistoryDataBackend& Historian::backend()
+{
+    return m_backend;
+}
+
+//*****************************************************************************
+
 bool Historian::setUpdateNode(
     NodeId& nodeId,
     Server& server,
@@ -573,7 +590,7 @@ bool Historian::setUpdateNode(
 {
     UA_HistorizingNodeIdSettings setting;
     setting.pollingInterval             = pollInterval;
-    setting.historizingBackend          = m_backend; // set the memory database
+    setting.historizingBackend          = backend();
     setting.maxHistoryDataResponseSize  = responseSize;
     setting.historizingUpdateStrategy   = UA_HISTORIZINGUPDATESTRATEGY_VALUESET;
     setting.userContext                 = context;
@@ -600,7 +617,7 @@ bool Historian::setPollNode(NodeId& nodeId,
                                        void* context)
 {
     UA_HistorizingNodeIdSettings setting;
-    setting.historizingBackend          = m_backend; // set the memory database
+    setting.historizingBackend          = backend();
     setting.pollingInterval             = pollInterval;
     setting.maxHistoryDataResponseSize  = responseSize;
     setting.historizingUpdateStrategy   = UA_HISTORIZINGUPDATESTRATEGY_POLL;
@@ -622,7 +639,7 @@ bool Historian::setUserNode(
     void*   context)
 {
     UA_HistorizingNodeIdSettings setting;
-    setting.historizingBackend          = m_backend; // set the memory database
+    setting.historizingBackend          = backend();
     setting.pollingInterval             = pollInterval;
     setting.maxHistoryDataResponseSize  = responseSize;
     setting.historizingUpdateStrategy   = UA_HISTORIZINGUPDATESTRATEGY_USER;

--- a/src/historydatabase.cpp
+++ b/src/historydatabase.cpp
@@ -646,26 +646,24 @@ MemoryHistorian::MemoryHistorian(
 
 //*****************************************************************************
 
-SQLiteHistorian::SQLiteHistorian(const char* dbFileName,
-                                     size_t numberNodes,
-                                     size_t maxValuesPerNode)
+SQLiteHistorianCyclicBuffered::SQLiteHistorianCyclicBuffered(const char* dbFileName,
+                                                             size_t numberNodes,
+                                                             size_t maxValuesPerNode,
+                                                             size_t pruneInterval)
 {
-    size_t defaultPruneInterval = 10;
     gathering() = UA_HistoryDataGathering_Default(numberNodes);
     database()  = UA_HistoryDatabase_default(gathering());
-    UA_HistoryDataBackend memoryBackend = UA_HistoryDataBackend_Memory_Circular(numberNodes, maxValuesPerNode);
-    backend() = UA_HistoryDataBackend_SQLite_Circular(memoryBackend, dbFileName, defaultPruneInterval, maxValuesPerNode);
+    backend() = UA_HistoryDataBackend_SQLite_Circular(dbFileName, pruneInterval, maxValuesPerNode);
 }
 
-SQLiteHistorian::SQLiteHistorian(const char* dbFileName,
-                                 size_t numberNodes,
-                                 size_t maxValuesPerNode,
-                                 UA_DateTime maxBufferedTime)
+SQLiteHistorianTimeBuffered::SQLiteHistorianTimeBuffered(const char* dbFileName,
+                                                         size_t numberNodes,
+                                                         UA_DateTime maxBufferedTimeSec,
+                                                         size_t pruneInterval)
 {
-    size_t defaultPruneInterval         = 10;
-    gathering()                         = UA_HistoryDataGathering_Default(numberNodes);
-    database()                          = UA_HistoryDatabase_default(gathering());
-    UA_HistoryDataBackend memoryBackend = UA_HistoryDataBackend_Memory_Circular(numberNodes, maxValuesPerNode);
-    backend() = UA_HistoryDataBackend_SQLite_Circular(memoryBackend, dbFileName, defaultPruneInterval, maxValuesPerNode);
+    gathering() = UA_HistoryDataGathering_Default(numberNodes);
+    database()  = UA_HistoryDatabase_default(gathering());
+    backend()   = UA_HistoryDataBackend_SQLite_TimeBuffered(dbFileName, pruneInterval, maxBufferedTimeSec);
 }
+
 }  // namespace Open62541


### PR DESCRIPTION
Hi Jean-Joël,

I will be leaving ThermoFisher, therefore it is probably best to have the changes for Cervino OPC-UA merged into your open62541Cpp repository as well.

Main change is introduction of SQLiteHistorianTimeBuffered and SQLiteHistorianCyclicBuffered backends.
These use sqlite to make the history persistent over restarts of the application. We currently use SQLiteHistorianTimeBuffered instead of MemoryHistorian.
Jochem did some additional changes w.r.t. the build/cmake configuration.

Regards,
Ronald